### PR TITLE
v1.03 bugfixes

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,32 @@ Questie-335 Ascension Edition
 CHANGELOG
 ========================================
 
+Version 9.5.1-ascension-v1.0.2 (December 15, 2025)
+--------------------------------------------------------
+BUG FIXES:
+  * Fixed "attempt to index field 'npcData' (a string value)" error during initialization
+  * Added type checking for npcData before accessing it as a table
+  * Fixed FixMapCoordinates() to verify database is loaded before applying fixes
+  * Fixed dynamic NPC collection to check database state
+  * Fixed "/questie ascension export" command crash
+  * Removed addon folder name restriction - now supports both:
+    - "Questie-335" (original name)
+    - "Questie-335-ascension" (new name)
+  * Removed non-Ascension realm names from detection:
+    - Removed: Laughing Skull, Sargeras, Andorhal (not Ascension servers)
+
+FEATURES:
+  * Flexible addon folder naming - works with any valid name variant
+  * Confirmed map coordinate fixes only for Map ID 1519 (Stormwind +6.8, +10.1)
+
+TECHNICAL CHANGES:
+  * Added type safety checks in AscensionLoader.lua
+  * Improved error handling for database access
+  * Better initialization sequence validation
+  * Updated VersionCheck.lua to allow multiple folder names
+  * Verified coordinate offset logic matches pfQuest-ascension exactly
+
+
 Version 9.5.1-ascension-v1.0.1-beta (December 15, 2025)
 --------------------------------------------------------
 BUG FIXES:

--- a/Modules/AscensionLoader.lua
+++ b/Modules/AscensionLoader.lua
@@ -73,9 +73,10 @@ function AscensionLoader:FixMapCoordinates()
     }
     
     -- Apply fixes to NPC coords
-    if QuestieDB.npcData then
+    -- Check if npcData is a table (not a string) before iterating
+    if QuestieDB.npcData and type(QuestieDB.npcData) == "table" then
         for npcId, npcData in pairs(QuestieDB.npcData) do
-            if npcData.spawns then
+            if type(npcData) == "table" and npcData.spawns then
                 for zoneId, spawns in pairs(npcData.spawns) do
                     if mapFixes[zoneId] then
                         local fix = mapFixes[zoneId]
@@ -92,9 +93,9 @@ function AscensionLoader:FixMapCoordinates()
     end
     
     -- Apply fixes to Object coords
-    if QuestieDB.objectData then
+    if QuestieDB.objectData and type(QuestieDB.objectData) == "table" then
         for objectId, objectData in pairs(QuestieDB.objectData) do
-            if objectData.spawns then
+            if type(objectData) == "table" and objectData.spawns then
                 for zoneId, spawns in pairs(objectData.spawns) do
                     if mapFixes[zoneId] then
                         local fix = mapFixes[zoneId]
@@ -303,6 +304,12 @@ function AscensionLoader:UPDATE_MOUSEOVER_UNIT()
     end
     
     -- Store in database
+    -- Make sure npcData is initialized as a table
+    if type(QuestieDB.npcData) ~= "table" then
+        Questie:Debug(Questie.DEBUG_CRITICAL, "[AscensionLoader] WARNING: npcData is not a table, skipping NPC storage")
+        return
+    end
+    
     if not self.discoveredNPCs[npcId] then
         self.discoveredNPCs[npcId] = true
         QuestieDB.npcData[npcId] = npcEntry

--- a/Modules/GitHubVersionCheck.lua
+++ b/Modules/GitHubVersionCheck.lua
@@ -2,7 +2,7 @@
 local GitHubVersionCheck = {}
 
 -- Current version from TOC
-GitHubVersionCheck.CURRENT_VERSION = "9.5.1-ascension-v1.0.1-beta"
+GitHubVersionCheck.CURRENT_VERSION = "9.5.1-ascension-v1.0.2"
 GitHubVersionCheck.GITHUB_REPO = "vem882/Questie-335-ascension"
 GitHubVersionCheck.CHECK_INTERVAL = 3600 -- Check once per hour (in seconds)
 GitHubVersionCheck.lastCheck = 0

--- a/Modules/VersionCheck.lua
+++ b/Modules/VersionCheck.lua
@@ -8,27 +8,37 @@ local WOW_PROJECT_WRATH_CLASSIC = QuestieCompat.WOW_PROJECT_WRATH_CLASSIC
 local WOW_PROJECT_ID = QuestieCompat.WOW_PROJECT_ID
 
 -- Check addon is not renamed to avoid conflicts in global name space.
+-- Allow both "Questie-335" and "Questie-335-ascension" folder names
 if (not QuestieCompat.Is335) and addonName ~= "Questie" then
-    local msg = { "You have renamed Questie addon.", "This is restricted to avoid issues.", "Please remove '"..addonName.."'", "and reinstall the original version."}
-    StaticPopupDialogs["QUESTIE_ADDON_NAME_ERROR"] = {
-        text = "|cffff0000ERROR|r\n"..msg[1].."\n"..msg[2].."\n\n"..msg[3].."\n"..msg[4],
-        button2 = "OK",
-        hasEditBox = false,
-        whileDead = true,
-        timeout = 0 -- 335
+    -- For Questie-335, allow flexible naming (Questie-335 or Questie-335-ascension)
+    local validNames = {
+        ["Questie"] = true,
+        ["Questie-335"] = true,
+        ["Questie-335-ascension"] = true
     }
+    
+    if not validNames[addonName] and not QuestieCompat.Is335 then
+        local msg = { "You have renamed Questie addon.", "This is restricted to avoid issues.", "Please remove '"..addonName.."'", "and reinstall the original version."}
+        StaticPopupDialogs["QUESTIE_ADDON_NAME_ERROR"] = {
+            text = "|cffff0000ERROR|r\n"..msg[1].."\n"..msg[2].."\n\n"..msg[3].."\n"..msg[4],
+            button2 = "OK",
+            hasEditBox = false,
+            whileDead = true,
+            timeout = 0 -- 335
+        }
 
-    C_Timer.After(4, function()
-        DEFAULT_CHAT_FRAME:AddMessage("---------------------------------")
-        DEFAULT_CHAT_FRAME:AddMessage("|cffff0000ERROR|r: |cff42f5ad"..msg[1].."|r")
-        DEFAULT_CHAT_FRAME:AddMessage("|cffff0000ERROR|r: |cff42f5ad"..msg[2].."|r")
-        DEFAULT_CHAT_FRAME:AddMessage("|cffff0000ERROR|r: |cff42f5ad"..msg[3].."|r")
-        DEFAULT_CHAT_FRAME:AddMessage("|cffff0000ERROR|r: |cff42f5ad"..msg[4].."|r")
-        DEFAULT_CHAT_FRAME:AddMessage("---------------------------------")
-        error("ERROR: "..msg[1].." "..msg[2].." "..msg[3])
-    end)
-    StaticPopup_Show("QUESTIE_ADDON_NAME_ERROR")
-    return
+        C_Timer.After(4, function()
+            DEFAULT_CHAT_FRAME:AddMessage("---------------------------------")
+            DEFAULT_CHAT_FRAME:AddMessage("|cffff0000ERROR|r: |cff42f5ad"..msg[1].."|r")
+            DEFAULT_CHAT_FRAME:AddMessage("|cffff0000ERROR|r: |cff42f5ad"..msg[2].."|r")
+            DEFAULT_CHAT_FRAME:AddMessage("|cffff0000ERROR|r: |cff42f5ad"..msg[3].."|r")
+            DEFAULT_CHAT_FRAME:AddMessage("|cffff0000ERROR|r: |cff42f5ad"..msg[4].."|r")
+            DEFAULT_CHAT_FRAME:AddMessage("---------------------------------")
+            error("ERROR: "..msg[1].." "..msg[2].." "..msg[3])
+        end)
+        StaticPopup_Show("QUESTIE_ADDON_NAME_ERROR")
+        return
+    end
 end
 
 if Questie then

--- a/Questie-335.toc
+++ b/Questie-335.toc
@@ -1,12 +1,12 @@
 ## Interface: 30300
-## Title: Questie-335|cFF00FF00 v9.5.1-ascension v1.0.1 beta|r
+## Title: Questie-335|cFF00FF00 v9.5.1-ascension v1.0.2|r
 ## Author: Aero/Logon/Muehe/TheCrux(BreakBB)/Drejjmit/Dyaxler/Schaka/Zoey/Everyone else
 ## Notes: A standalone Classic QuestHelper with Ascension WoW support
 ## Notes-esMX: Ayundante de misión
 ## Notes-esES: Ayundante de misión
 ## Notes-ptBR: Ajudante de missão
 ## Notes-frFR: Assistant de quête
-## Version: 9.5.1-ascension-v1.0.1-beta
+## Version: 9.5.1-ascension-v1.0.2
 ## RequiredDeps:
 ## OptionalDeps: Ace3, CallbackHandler-1.0, HereBeDragons, LibDataBroker-1.1, LibDBIcon-1.0, LibSharedMedia-3.0, LibStub, LibUIDropDownMenu
 ## SavedVariables: QuestieConfig


### PR DESCRIPTION
BUG FIXES:
  * Fixed "attempt to index field 'npcData' (a string value)" error during initialization
  * Added type checking for npcData before accessing it as a table
  * Fixed FixMapCoordinates() to verify database is loaded before applying fixes
  * Fixed dynamic NPC collection to check database state
  * Fixed "/questie ascension export" command crash
  * Removed addon folder name restriction - now supports both:
    - "Questie-335" (original name)
    - "Questie-335-ascension" (new name)
  * Removed non-Ascension realm names from detection:
    - Removed: Laughing Skull, Sargeras, Andorhal (not Ascension servers)