### PR TITLE
fix: tooltips no longer have duplicate quest text

### DIFF
--- a/Modules/Options/QuestieOptions.lua
+++ b/Modules/Options/QuestieOptions.lua
@@ -122,8 +122,8 @@ _CreateOptionsTable = function()
     coroutine.yield()
     local auto_tab = QuestieOptions.tabs.auto:Initialize()
     coroutine.yield()
-    --local tooltip_tab = QuestieOptions.tabs.tooltip:Initialize()
-    --coroutine.yield()
+    local tooltip_tab = QuestieOptions.tabs.tooltip:Initialize()
+    coroutine.yield()
     --local sounds_tab = QuestieOptions.tabs.sounds:Initialize()
     --coroutine.yield()
     local nameplate_tab = QuestieOptions.tabs.nameplate:Initialize()
@@ -145,7 +145,7 @@ _CreateOptionsTable = function()
             icons_tab = icons_tab,
             tracker_tab = tracker_tab,
             auto_tab = auto_tab,
-            --tooltip_tab = tooltip_tab,
+            tooltip_tab = tooltip_tab,
             --sounds_tab = sounds_tab,
             nameplate_tab = nameplate_tab,
             dbm_hud_tab = dbm_hud_tab,

--- a/Questie-335.toc
+++ b/Questie-335.toc
@@ -229,6 +229,7 @@ Modules\Options\GeneralTab\QuestieOptionsGeneral.lua
 Modules\Options\IconsTab\QuestieOptionsIcons.lua
 Modules\Options\NameplateTab\QuestieOptionsNameplate.lua
 Modules\Options\TrackerTab\QuestieOptionsTracker.lua
+Modules\Options\TooltipTab\QuestieOptionsTooltip.lua
 
 # Cleanup
 Modules\QuestieCleanup.lua


### PR DESCRIPTION
Also re-enables the tooltip options tab